### PR TITLE
Fixed extract headers parameter.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -121,7 +121,7 @@ export default class OpentracingExtension<TContext extends SpanContext>
 
     let headers = infos.request && infos.request.headers
     if (headers && typeof headers.get === 'function') {
-      headers = this.mapToObj(infos.request.headers)
+      headers = this.mapToObj(infos.request.headers as Map<string, any>)
     }
 
     const externalSpan =

--- a/src/index.ts
+++ b/src/index.ts
@@ -119,16 +119,19 @@ export default class OpentracingExtension<TContext extends SpanContext>
       return;
     }
 
-    let headers = infos.request && infos.request.headers
-    if (headers && typeof headers.get === 'function') {
-      headers = this.mapToObj(infos.request.headers as Map<string, any>)
+    let headers
+    let tmpHeaders = infos.request && infos.request.headers as unknown as Map<string, any>
+    if (tmpHeaders && typeof tmpHeaders.get === 'function') {
+      headers = this.mapToObj(tmpHeaders)
+    } else {
+      headers = tmpHeaders
     }
 
     const externalSpan =
       infos.request && infos.request.headers
         ? this.serverTracer.extract(
             opentracing.FORMAT_HTTP_HEADERS,
-            infos.request.headers
+            headers
           )
         : undefined;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,9 +104,24 @@ export default class OpentracingExtension<TContext extends SpanContext>
     this.onFieldResolve = onFieldResolve;
   }
 
+  mapToObj(inputMap: Map<string, any>) {
+    let obj: { [key: string]: string } = {};
+
+    inputMap.forEach(function(value, key){
+      obj[key] = value
+    });
+
+    return obj;
+  }
+
   requestDidStart(infos: RequestStart) {
     if (!this.shouldTraceRequest(infos)) {
       return;
+    }
+
+    let headers = infos.request && infos.request.headers
+    if (headers && typeof headers.get === 'function') {
+      headers = this.mapToObj(infos.request.headers)
     }
 
     const externalSpan =


### PR DESCRIPTION
Apollo is converting request object to map, but open tracing interface (specifically jaeger client) expects object in extract method, therefore converting headers (only if it's type of map) to object.

