### PR TITLE
fix(headers): extract headers parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "apollo-server-env": "*",
     "graphql": "0.10.x - 14.2.x",
     "opentracing": "*",
-    "apollo-server": "2.4.8"
+    "apollo-server": "^2.4.8"
   },
   "dependencies": {
     "graphql-extensions": "^0.5.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "apollo-opentracing",
-  "version": "0.0.0-development",
+  "name": "@blabu.com/apollo-opentracing",
+  "version": "1.2.0",
   "description": "Trace your GraphQL server with Opentracing",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -28,13 +28,14 @@
       "node"
     ]
   },
-  "repository": "DanielMSchmidt/apollo-opentracing",
+  "repository": "voslartomas/apollo-opentracing",
   "author": "Daniel Schmidt <danielmschmidt92@gmail.com>",
   "license": "MIT",
   "peerDependencies": {
     "apollo-server-env": "*",
     "graphql": "0.10.x - 14.2.x",
-    "opentracing": "*"
+    "opentracing": "*",
+    "apollo-server": "2.4.8"
   },
   "dependencies": {
     "graphql-extensions": "^0.5.7"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@blabu.com/apollo-opentracing",
-  "version": "1.2.0",
+  "name": "apollo-opentracing",
+  "version": "0.0.0-development",
   "description": "Trace your GraphQL server with Opentracing",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -28,7 +28,7 @@
       "node"
     ]
   },
-  "repository": "voslartomas/apollo-opentracing",
+  "repository": "DanielMSchmidt/apollo-opentracing",
   "author": "Daniel Schmidt <danielmschmidt92@gmail.com>",
   "license": "MIT",
   "peerDependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -104,16 +104,34 @@ export default class OpentracingExtension<TContext extends SpanContext>
     this.onFieldResolve = onFieldResolve;
   }
 
+  mapToObj(inputMap: Map<string, any>) {
+    let obj: { [key: string]: string } = {};
+
+    inputMap.forEach(function(value, key){
+      obj[key] = value
+    });
+
+    return obj;
+  }
+
   requestDidStart(infos: RequestStart) {
     if (!this.shouldTraceRequest(infos)) {
       return;
+    }
+
+    let headers
+    let tmpHeaders = infos.request && infos.request.headers as unknown as Map<string, any>
+    if (tmpHeaders && typeof tmpHeaders.get === 'function') {
+      headers = this.mapToObj(tmpHeaders)
+    } else {
+      headers = tmpHeaders
     }
 
     const externalSpan =
       infos.request && infos.request.headers
         ? this.serverTracer.extract(
             opentracing.FORMAT_HTTP_HEADERS,
-            infos.request.headers
+            headers
           )
         : undefined;
 


### PR DESCRIPTION
Apollo is converting request object to map, but open tracing interface (specifically jaeger client) expects object in extract method, therefore converting headers (only if it's type of map) to object.

