### PR TITLE
fix: queryString in tag instead of log

### DIFF
--- a/src/__tests__/__snapshots__/integration-test.ts.snap
+++ b/src/__tests__/__snapshots__/integration-test.ts.snap
@@ -3,73 +3,95 @@
 exports[`integration with apollo-server alias with fragment works 1`] = `
 request:1
    finished: true
-   logs:
-   1. {"queryString":"\\n        fragment F on A {\\n          dos: two\\n        }\\n\\n        query {\\n        a {\\n          ...F\\n        }\\n      }"}
+
+   tags:
+   1. {"key":"queryString","value":"\\n        fragment F on A {\\n          dos: two\\n        }\\n\\n        query {\\n        a {\\n          ...F\\n        }\\n      }"}
 +-- a:2
       finished: true
+
    +-- dos:3
          finished: true
+
 
 `;
 
 exports[`integration with apollo-server alias works 1`] = `
 request:1
    finished: true
-   logs:
-   1. {"queryString":"query {\\n        a {\\n          uno: one\\n          two\\n        }\\n      }"}
+
+   tags:
+   1. {"key":"queryString","value":"query {\\n        a {\\n          uno: one\\n          two\\n        }\\n      }"}
 +-- a:2
       finished: true
+
    +-- uno:3
          finished: true
+
    +-- two:4
          finished: true
+
 
 `;
 
 exports[`integration with apollo-server correct span nesting 1`] = `
 request:1
    finished: true
-   logs:
-   1. {"queryString":"query {\\n        a {\\n          one\\n          two\\n        }\\n      }"}
+
+   tags:
+   1. {"key":"queryString","value":"query {\\n        a {\\n          one\\n          two\\n        }\\n      }"}
 +-- a:2
       finished: true
+
    +-- one:3
          finished: true
+
    +-- two:4
          finished: true
+
 
 `;
 
 exports[`integration with apollo-server does not start a field resolver span if the parent field resolver was not traced 1`] = `
 request:1
    finished: true
-   logs:
-   1. {"queryString":"query {\\n        a {\\n          one\\n          two\\n        }\\n        b {\\n          four\\n        }\\n      }"}
+
+   tags:
+   1. {"key":"queryString","value":"query {\\n        a {\\n          one\\n          two\\n        }\\n        b {\\n          four\\n        }\\n      }"}
 +-- b:2
       finished: true
+
    +-- four:3
          finished: true
+
 
 `;
 
 exports[`integration with apollo-server implements traces for arrays 1`] = `
 request:1
    finished: true
-   logs:
-   1. {"queryString":"query {\\n        as {\\n          one\\n          two\\n        }\\n      }"}
+
+   tags:
+   1. {"key":"queryString","value":"query {\\n        as {\\n          one\\n          two\\n        }\\n      }"}
 +-- as:2
       finished: true
+
    +-- one:3
          finished: true
+
    +-- two:4
          finished: true
+
    +-- one:5
          finished: true
+
    +-- two:6
          finished: true
+
    +-- one:7
          finished: true
+
    +-- two:8
          finished: true
+
 
 `;

--- a/src/__tests__/index-test.ts
+++ b/src/__tests__/index-test.ts
@@ -6,6 +6,7 @@ describe("Apollo Tracing", () => {
   beforeEach(() => {
     const span = {
       finish: jest.fn(),
+      setTag: jest.fn(),
       log: jest.fn()
     };
 
@@ -68,7 +69,7 @@ describe("Apollo Tracing", () => {
       const cb = tracingMiddleware.requestDidStart({ queryString: "query {}" });
       expect(server.startSpan).toHaveBeenCalled();
       expect(local.startSpan).not.toHaveBeenCalled();
-      expect(server.span.log).toHaveBeenCalledWith({ queryString: "query {}" });
+      expect(server.span.setTag).toHaveBeenCalledWith("queryString", "query {}");
 
       cb();
       expect(server.span.finish).toHaveBeenCalled();
@@ -78,7 +79,7 @@ describe("Apollo Tracing", () => {
       const cb = tracingMiddleware.requestDidStart({ queryString: "query {}" });
       expect(server.startSpan).toHaveBeenCalled();
       expect(local.startSpan).not.toHaveBeenCalled();
-      expect(server.span.log).toHaveBeenCalledWith({ queryString: "query {}" });
+      expect(server.span.setTag).toHaveBeenCalledWith("queryString", "query {}");
 
       cb(new Error("ups"));
       expect(server.span.finish).toHaveBeenCalled();

--- a/src/__tests__/integration-test.ts
+++ b/src/__tests__/integration-test.ts
@@ -91,6 +91,7 @@ class MockTracer {
       name,
       options,
       logs: [],
+      tags: [],
       finished: false
     });
 
@@ -99,6 +100,10 @@ class MockTracer {
     return {
       log(object) {
         self.spans.find(span => span.id === spanId).logs.push(object);
+      },
+
+      setTag(key, value) {
+        self.spans.find(span => span.id === spanId).tags.push({"key": key, "value": value})
       },
 
       id: spanId,

--- a/src/index.ts
+++ b/src/index.ts
@@ -139,9 +139,7 @@ export default class OpentracingExtension<TContext extends SpanContext>
       childOf: externalSpan ? externalSpan : undefined
     });
 
-    rootSpan.log({
-      queryString: infos.queryString
-    });
+    rootSpan.setTag("queryString", infos.queryString);
     this.requestSpan = rootSpan;
 
     return () => {

--- a/src/test/span-serializer.ts
+++ b/src/test/span-serializer.ts
@@ -24,10 +24,19 @@ function logs(span: MockSpanTree, depth: number) {
   return "";
 }
 
+function tags(span: MockSpanTree, depth: number) {
+  if (span.tags && span.tags.length > 0) {
+    return `${TAB.repeat(depth + 1)}tags:\n${span.tags
+      .map((tag, index) => logLine(tag, index + 1, depth))
+      .join("\n")}\n`;
+  }
+  return "";
+}
+
 function tag(span: MockSpanTree, depth: number) {
   return `${span.name}:${span.id}\n${TAB.repeat(depth + 1)}finished: ${
     span.finished
-  }\n${logs(span, depth)}`;
+  }\n${logs(span, depth)}\n${tags(span, depth)}`;
 }
 
 function buildSpan(span: MockSpanTree, depth = 0) {

--- a/src/test/types.ts
+++ b/src/test/types.ts
@@ -4,6 +4,7 @@ export interface MockSpan {
   name: string;
   options?: any;
   logs: any[];
+  tags: any[];
   finished: boolean;
 }
 


### PR DESCRIPTION
As discussed in https://github.com/DanielMSchmidt/apollo-opentracing/issues/91 (but never implemented) I changed putting queryString into tags instead of logs

as a side note: I use elasticsearch as storage backend and in kibana I'm able to do searches with tags (each tag is a separate field in ES) but not with logs (all logs are as an array in one ES field - that makes problems)