### PR TITLE
feat: add processQueryStringTag function

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ When the request is not traced there will also be no traces of the field resolve
 
 There might be certain field resolvers that are not worth the tracing, e.g. when they get a value out of an object and need no further tracing. To control if you want a field resolver to be traced you can pass the `shouldTraceFieldResolver` option to the constructor. The function is called with the same arguments as your field resolver and you can get the name of the field by `info.fieldName`. When you return false no traces will be made of this field resolvers and all underlying ones.
 
+## Modifying span metadata
+
+If you'd like to add custom tags or logs to span you can construct the extension with `onRequestResolve`. The function is called with two arguments: span and infos `onRequestResolve?: (span: Span, info: RequestStart)`
+
 ## Contributing
 
 Please feel free to add issues with new ideas, bugs and anything that might come up.

--- a/src/__tests__/__snapshots__/integration-test.ts.snap
+++ b/src/__tests__/__snapshots__/integration-test.ts.snap
@@ -4,8 +4,6 @@ exports[`integration with apollo-server alias with fragment works 1`] = `
 request:1
    finished: true
 
-   tags:
-   1. {"key":"queryString","value":"\\n        fragment F on A {\\n          dos: two\\n        }\\n\\n        query {\\n        a {\\n          ...F\\n        }\\n      }"}
 +-- a:2
       finished: true
 
@@ -19,8 +17,6 @@ exports[`integration with apollo-server alias works 1`] = `
 request:1
    finished: true
 
-   tags:
-   1. {"key":"queryString","value":"query {\\n        a {\\n          uno: one\\n          two\\n        }\\n      }"}
 +-- a:2
       finished: true
 
@@ -37,8 +33,6 @@ exports[`integration with apollo-server correct span nesting 1`] = `
 request:1
    finished: true
 
-   tags:
-   1. {"key":"queryString","value":"query {\\n        a {\\n          one\\n          two\\n        }\\n      }"}
 +-- a:2
       finished: true
 
@@ -55,8 +49,6 @@ exports[`integration with apollo-server does not start a field resolver span if 
 request:1
    finished: true
 
-   tags:
-   1. {"key":"queryString","value":"query {\\n        a {\\n          one\\n          two\\n        }\\n        b {\\n          four\\n        }\\n      }"}
 +-- b:2
       finished: true
 
@@ -70,8 +62,6 @@ exports[`integration with apollo-server implements traces for arrays 1`] = `
 request:1
    finished: true
 
-   tags:
-   1. {"key":"queryString","value":"query {\\n        as {\\n          one\\n          two\\n        }\\n      }"}
 +-- as:2
       finished: true
 

--- a/src/__tests__/index-test.ts
+++ b/src/__tests__/index-test.ts
@@ -69,7 +69,6 @@ describe("Apollo Tracing", () => {
       const cb = tracingMiddleware.requestDidStart({ queryString: "query {}" });
       expect(server.startSpan).toHaveBeenCalled();
       expect(local.startSpan).not.toHaveBeenCalled();
-      expect(server.span.setTag).toHaveBeenCalledWith("queryString", "query {}");
 
       cb();
       expect(server.span.finish).toHaveBeenCalled();
@@ -79,7 +78,6 @@ describe("Apollo Tracing", () => {
       const cb = tracingMiddleware.requestDidStart({ queryString: "query {}" });
       expect(server.startSpan).toHaveBeenCalled();
       expect(local.startSpan).not.toHaveBeenCalled();
-      expect(server.span.setTag).toHaveBeenCalledWith("queryString", "query {}");
 
       cb(new Error("ups"));
       expect(server.span.finish).toHaveBeenCalled();


### PR DESCRIPTION
This is a draft of a PR.

Problem:
I'd like to be able to modify the content of graphql queryString which is sent to Jaeger as one of the tags. F.e. sometimes I'd like to hide some sensitive data (tokens, keys, etc).

It would be possible to pass a function to the extension constructor (similar to `shouldTraceRequest` etc). And it would be up to the consumer of the extension how to process the query string.

Let me know if it's a valid approach from your point of view. If so I'd continue on that (adding docs, tests, etc)