### PR TITLE
feat: Adopt Apollo plugin interface

### DIFF
--- a/src/context.ts
+++ b/src/context.ts
@@ -19,10 +19,14 @@ export function buildPath(path: ResponsePath | undefined) {
   return segments.reverse().join(".");
 }
 
-export interface SpanContext extends Object {
-  _spans: Map<string, Span>;
-  getSpanByPath(info: ResponsePath): Span | undefined;
-  addSpan(span: Span, info: GraphQLResolveInfo): void;
+export class SpanContext {
+  _spans = new Map<string, Span>();
+  getSpanByPath(path: ResponsePath): Span | undefined {
+    return this._spans.get(buildPath(isArrayPath(path) ? path.prev : path));
+  };
+  addSpan(span: Span, info: GraphQLResolveInfo): void {
+    this._spans.set(buildPath(info.path), span);
+  };
   // Passed in from the outside context
   requestSpan?: Span;
 }
@@ -49,4 +53,8 @@ export function addContextHelpers(obj: any): SpanContext {
   };
 
   return obj;
+}
+
+export function makeContextHelper() {
+  return new SpanContext();
 }


### PR DESCRIPTION
This PR is not yet cleaned up and should be considered a work in progress.

This change does:
- Replaces Apollo extension API usage with plugin API usage.
- Removes manipulation of the context. *probably requires discussion*
- ~Replaces `opentracing` with `opentelemetry` equivalents as applicable.~ This didn't work. Introduces too many new layers

I had a lot of trouble getting the context management sorted out and ultimately couldn't figure out a way to make everything type-safe. Manipulating the Apollo context, especially in the monkey-patch way that is used, seemed problematic to me, but maybe I just don't know how to properly write the TS for it.

Thus, I opted to just store the tracing helpers on the side in a WeakMap. The helpers are still provided back to the user and they may very well store the reference on the context, but then the user is in charge of doing that and adjusting their own type definition for their context.

Fixes #330